### PR TITLE
Add Changelog file and release version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [1.0.0] - 2017-06-22
+First release of haptic-devices, containing the `geomagicdriver`, `hapticdevicewrapper` and `hapticdeviceclient`. 
+This release is compatible with YARP from 2.3.70 to 3.2 .


### PR DESCRIPTION
I want to work on https://github.com/robotology/haptic-devices/issues/6 , but before of this I prefer to clearly mark the pre-YARP 3.0 version. 
For this, I added a changelog files following the format in https://keepachangelog.com/en/1.0.0/, and I tagged a 1.0.0 version . For the release data, I used the date of the latest commit. 

After this PR is merged, I intend to tag this commit as the release v1.0.0 .