### PR TITLE
Update to YARP 3.2 and generic cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+The minimum version of YARP required to use `haptic-devices` is now 3.2 .
+
+### Changed
+- Compilation of `hapticdevicewrapper` and `hapticdeviceclient` is now ON by default.
+- CMake options for compilation of devices changed from `ENABLE_hapticdevicemod_<devicename>` to `ENABLE_<devicename>`.
+
+### Removed
+- The compilation of the custom `hapticdevicemod` executable to launch `haptic-devices`'s YARP devices has been removed. The devices can be launched using `yarpdev` or `yarprobotinterface` deployers.
+
 ## [1.0.0] - 2017-06-22
 First release of haptic-devices, containing the `geomagicdriver`, `hapticdevicewrapper` and `hapticdeviceclient`. 
 This release is compatible with YARP from 2.3.70 to 3.2 .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ yarp_begin_plugin_library(hapticdevicemod)
 yarp_end_plugin_library(hapticdevicemod)
 
 install(TARGETS hapticdevicemod EXPORT hapticdevicemod
-		LIBRARY DESTINATION lib COMPONENT shlib
-		ARCHIVE DESTINATION lib
-		PUBLIC_HEADER DESTINATION include/hapticdevicemod COMPONENT dev)
+        LIBRARY DESTINATION lib COMPONENT shlib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/hapticdevicemod COMPONENT dev)
 
 yarp_install(FILES conf/geomagic.xml DESTINATION ${HAPTICDEVICE_CONTEXTS_INSTALL_DIR}/geomagic)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,8 @@
 cmake_minimum_required(VERSION 2.8.9)
 project(haptic-devices)
 
-find_package(YARP REQUIRED)
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
+find_package(YARP 3.2 REQUIRED)
 
-include(YarpPlugin)
 set(BUILD_SHARED_LIBS TRUE)
 
 yarp_configure_external_installation(hapticdevice WITH_PLUGINS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,16 +10,10 @@ find_package(YARP 3.2 REQUIRED)
 set(BUILD_SHARED_LIBS TRUE)
 
 yarp_configure_external_installation(hapticdevice WITH_PLUGINS)
-yarp_begin_plugin_library(hapticdevicemod)
-    add_subdirectory(drivers)
-    add_subdirectory(wrapper)
-    add_subdirectory(client)
-yarp_end_plugin_library(hapticdevicemod)
 
-install(TARGETS hapticdevicemod EXPORT hapticdevicemod
-        LIBRARY DESTINATION lib COMPONENT shlib
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include/hapticdevicemod COMPONENT dev)
+add_subdirectory(drivers)
+add_subdirectory(wrapper)
+add_subdirectory(client)
 
 yarp_install(FILES conf/geomagic.xml DESTINATION ${HAPTICDEVICE_CONTEXTS_INSTALL_DIR}/geomagic)
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ prior to pairing the device. This will make the driver work outside US.
 - [icub-contrib-common](https://github.com/robotology/icub-contrib-common) (only for examples and tests)
 
 ## Compiling and Installing the YARP plugins
-1. Set up the building project by means of **cmake**. Remember to tick on the drivers:
-`hapticdevicewrapper`, `hapticdeviceclient` and the physical drivers you need, e.g. `geomagicdriver`.
+1. Set up the building project by means of **cmake**. If you need to compile some physical drivers you need, remember
+to enable the relative CMake variable, e.g. `ENABLE_geomagicdriver`.
 2. Compile and install the project.
 3. Set up the environment variable **`hapticdevice_DIR`** pointing where the project gets installed
 (should be the same path used for `CMAKE_INSTALL_PREFIX`).

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -7,7 +7,7 @@ yarp_prepare_plugin(hapticdeviceclient CATEGORY device
                                        INCLUDE hapticdeviceClient.h
                                        EXTRA_CONFIG WRAPPER=hapticdeviceclient)
 
-if(ENABLE_hapticdevicemod_hapticdeviceclient)
+if(ENABLE_hapticdeviceclient)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     include_directories(${PROJECT_SOURCE_DIR}/interface)
     include_directories(${PROJECT_SOURCE_DIR}/common)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -5,6 +5,7 @@
 yarp_prepare_plugin(hapticdeviceclient CATEGORY device
                                        TYPE HapticDeviceClient
                                        INCLUDE hapticdeviceClient.h
+                                       DEFAULT ON
                                        EXTRA_CONFIG WRAPPER=hapticdeviceclient)
 
 if(ENABLE_hapticdeviceclient)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -8,7 +8,6 @@ yarp_prepare_plugin(hapticdeviceclient CATEGORY device
                                        EXTRA_CONFIG WRAPPER=hapticdeviceclient)
 
 if(ENABLE_hapticdevicemod_hapticdeviceclient)
-    include_directories(${YARP_INCLUDE_DIRS})
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     include_directories(${PROJECT_SOURCE_DIR}/interface)
     include_directories(${PROJECT_SOURCE_DIR}/common)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -17,8 +17,7 @@ if(ENABLE_hapticdevicemod_hapticdeviceclient)
     target_link_libraries(hapticdeviceclient ${YARP_LIBRARIES})
     yarp_install(TARGETS hapticdeviceclient
                  COMPONENT Runtime
-                 LIBRARY DESTINATION ${HAPTICDEVICE_DYNAMIC_PLUGINS_INSTALL_DIR})
-
-    yarp_install(FILES hapticdeviceclient.ini DESTINATION ${HAPTICDEVICE_PLUGIN_MANIFESTS_INSTALL_DIR})
+                 LIBRARY DESTINATION ${HAPTICDEVICE_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 YARP_INI DESTINATION ${HAPTICDEVICE_PLUGIN_MANIFESTS_INSTALL_DIR})
 endif()
 

--- a/client/hapticdeviceclient.ini
+++ b/client/hapticdeviceclient.ini
@@ -1,5 +1,0 @@
-[plugin hapticdeviceclient]
-type device
-name hapticdeviceclient
-library hapticdeviceclient
-wrapper hapticdevicesclient

--- a/common/common.h
+++ b/common/common.h
@@ -14,15 +14,15 @@
 
 namespace hapticdevice {
     enum {
-        ack                = VOCAB3('a','c','k'),
-        nack               = VOCAB4('n','a','c','k'),
-        get_transformation = VOCAB4('g','t','r','a'),
-        set_transformation = VOCAB4('s','t','r','a'),
-        stop_feedback      = VOCAB4('s','t','o','p'),
-        is_cartesian       = VOCAB3('i','s','f'),
-        set_cartesian      = VOCAB4('s','c','a','r'),
-        set_joint          = VOCAB4('s','j','n','t'),
-        get_max            = VOCAB4('g','m','a','x')
+        ack                = yarp::os::createVocab('a','c','k'),
+        nack               = yarp::os::createVocab('n','a','c','k'),
+        get_transformation = yarp::os::createVocab('g','t','r','a'),
+        set_transformation = yarp::os::createVocab('s','t','r','a'),
+        stop_feedback      = yarp::os::createVocab('s','t','o','p'),
+        is_cartesian       = yarp::os::createVocab('i','s','f'),
+        set_cartesian      = yarp::os::createVocab('s','c','a','r'),
+        set_joint          = yarp::os::createVocab('s','j','n','t'),
+        get_max            = yarp::os::createVocab('g','m','a','x')
     };
 }
 

--- a/drivers/geomagic/CMakeLists.txt
+++ b/drivers/geomagic/CMakeLists.txt
@@ -73,7 +73,6 @@ if(ENABLE_hapticdevicemod_geomagicdriver)
         mark_as_advanced(GEOMAGIC_LIB_HLU_D)
     endif()
     
-    include_directories(${YARP_INCLUDE_DIRS})
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     include_directories(${GEOMAGIC_INCLUDE_DIRS})
     include_directories(${PROJECT_SOURCE_DIR}/interface)

--- a/drivers/geomagic/CMakeLists.txt
+++ b/drivers/geomagic/CMakeLists.txt
@@ -5,6 +5,7 @@
 yarp_prepare_plugin(geomagicdriver CATEGORY device
                                    TYPE GeomagicDriver
                                    INCLUDE geomagicDriver.h
+                                   DEFAULT OFF
                                    EXTRA_CONFIG WRAPPER=hapticdevicewrapper)
 
 if(ENABLE_geomagicdriver)

--- a/drivers/geomagic/CMakeLists.txt
+++ b/drivers/geomagic/CMakeLists.txt
@@ -82,7 +82,6 @@ if(ENABLE_hapticdevicemod_geomagicdriver)
     target_link_libraries(geomagicdriver ${YARP_LIBRARIES} ${GEOMAGIC_LIBRARIES})
     yarp_install(TARGETS geomagicdriver
                  COMPONENT Runtime
-                 LIBRARY DESTINATION ${HAPTICDEVICE_DYNAMIC_PLUGINS_INSTALL_DIR})
-
-    yarp_install(FILES geomagicdriver.ini DESTINATION ${HAPTICDEVICE_PLUGIN_MANIFESTS_INSTALL_DIR})
+                 LIBRARY DESTINATION ${HAPTICDEVICE_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 YARP_INI DESTINATION ${HAPTICDEVICE_PLUGIN_MANIFESTS_INSTALL_DIR})
 endif()

--- a/drivers/geomagic/CMakeLists.txt
+++ b/drivers/geomagic/CMakeLists.txt
@@ -7,7 +7,7 @@ yarp_prepare_plugin(geomagicdriver CATEGORY device
                                    INCLUDE geomagicDriver.h
                                    EXTRA_CONFIG WRAPPER=hapticdevicewrapper)
 
-if(ENABLE_hapticdevicemod_geomagicdriver)
+if(ENABLE_geomagicdriver)
     if(UNIX)
         set(GEOMAGIC_INCLUDE_DIRS)
         find_library(GEOMAGIC_LIB_HD  HD)

--- a/drivers/geomagic/geomagicdriver.ini
+++ b/drivers/geomagic/geomagicdriver.ini
@@ -1,5 +1,0 @@
-[plugin geomagicdriver]
-type device
-name geomagicdriver
-library geomagicdriver
-wrapper hapticdevicewrapper

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -9,7 +9,6 @@ yarp_prepare_plugin(hapticdevicewrapper CATEGORY device
 
 
 if(ENABLE_hapticdevicemod_hapticdevicewrapper)
-    include_directories(${YARP_INCLUDE_DIRS})
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     include_directories(${PROJECT_SOURCE_DIR}/interface)
     include_directories(${PROJECT_SOURCE_DIR}/common)

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -5,6 +5,7 @@
 yarp_prepare_plugin(hapticdevicewrapper CATEGORY device
                                         TYPE HapticDeviceWrapper
                                         INCLUDE hapticdeviceWrapper.h 
+                                        DEFAULT ON
                                         EXTRA_CONFIG WRAPPER=hapticdevicewrapper)
 
 

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -8,7 +8,7 @@ yarp_prepare_plugin(hapticdevicewrapper CATEGORY device
                                         EXTRA_CONFIG WRAPPER=hapticdevicewrapper)
 
 
-if(ENABLE_hapticdevicemod_hapticdevicewrapper)
+if(ENABLE_hapticdevicewrapper)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     include_directories(${PROJECT_SOURCE_DIR}/interface)
     include_directories(${PROJECT_SOURCE_DIR}/common)

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -18,8 +18,7 @@ if(ENABLE_hapticdevicemod_hapticdevicewrapper)
     target_link_libraries(hapticdevicewrapper ${YARP_LIBRARIES})
     yarp_install(TARGETS hapticdevicewrapper
                  COMPONENT Runtime
-                 LIBRARY DESTINATION ${HAPTICDEVICE_DYNAMIC_PLUGINS_INSTALL_DIR})
-
-    yarp_install(FILES hapticdevicewrapper.ini DESTINATION ${HAPTICDEVICE_PLUGIN_MANIFESTS_INSTALL_DIR})
+                 LIBRARY DESTINATION ${HAPTICDEVICE_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 YARP_INI DESTINATION ${HAPTICDEVICE_PLUGIN_MANIFESTS_INSTALL_DIR})
 endif()
 

--- a/wrapper/hapticdevicewrapper.ini
+++ b/wrapper/hapticdevicewrapper.ini
@@ -1,5 +1,0 @@
-[plugin hapticdevicewrapper]
-type device
-name hapticdevicewrapper
-library hapticdevicewrapper
-wrapper hapticdevicewrapper


### PR DESCRIPTION
The following minor user facing changes have been done (extracted from the changelog https://github.com/robotology/haptic-devices/compare/cleanup?expand=1#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR6):
   
> The minimum version of YARP required to use `haptic-devices` is now 3.2 .
>
> ### Changed
> - Compilation of `hapticdevicewrapper` and `hapticdeviceclient` is now ON by default.
> - CMake options for compilation of devices changed from  `ENABLE_hapticdevicemod_<devicename>` to `ENABLE_<devicename>`.
>
> ### Removed
> - The compilation of the custom `hapticdevicemod` executable to launch `haptic-devices`'s YARP devices has been removed. The devices can be launched using `yarpdev` or `yarprobotinterface` deployers.

Other (non user-facing) changes include removal of the use of deprecated feature of YARP, see the individual commits messages for more details. 
